### PR TITLE
Implement basic queue for check-in

### DIFF
--- a/simulador/mostrador.go
+++ b/simulador/mostrador.go
@@ -1,24 +1,39 @@
 package simulador
 
 type Mostrador struct {
-	// TODO: cola queue.Queue[*Persona]
+	cola       []*Persona
 	habilitado bool
 }
 
 func NewMostrador(habilitado bool) *Mostrador {
 	return &Mostrador{
+		cola:       make([]*Persona, 0),
 		habilitado: habilitado,
 	}
 }
 
 // HacerCola asigna a una persona a la cola del mostrador
 func (m *Mostrador) HacerCola(persona *Persona) {
-
+	if persona == nil {
+		return
+	}
+	persona.CambiarEstado(EnEspera)
+	m.cola = append(m.cola, persona)
 }
 
 // Tick ejecuta un tick del mostrador, procesando las personas en la cola
 func (m *Mostrador) Tick() {
+	if !m.habilitado || len(m.cola) == 0 {
+		return
+	}
 
+	// Atender a la primera persona en la cola
+	persona := m.cola[0]
+	m.cola = m.cola[1:]
+
+	persona.CambiarEstado(SiendoAtendido)
+	persona.CambiarEstado(Despachando)
+	persona.CambiarEstado(Retirandose)
 }
 
 func (m *Mostrador) Habilitado() bool {

--- a/simulador/persona.go
+++ b/simulador/persona.go
@@ -42,3 +42,18 @@ func NewPersona(documento uint, equipaje *Equipaje) *Persona {
 		TicketEquipaje:  nil,
 	}
 }
+
+// CambiarEstado actualiza el estado de la persona y registra el momento
+func (p *Persona) CambiarEstado(e Estado) {
+	p.Estado = e
+	p.InicioAccion = time.Now()
+}
+
+// Atender marca a la persona como siendo atendida
+func (p *Persona) Atender() { p.CambiarEstado(SiendoAtendido) }
+
+// DespacharEquipaje marca que la persona está despachando su equipaje
+func (p *Persona) DespacharEquipaje() { p.CambiarEstado(Despachando) }
+
+// Retirar marca que la persona se retira del mostrador
+func (p *Persona) Retirar() { p.CambiarEstado(Retirandose) }

--- a/simulador/simulador.go
+++ b/simulador/simulador.go
@@ -42,11 +42,30 @@ func (s *Simulador) Iniciar() {
 
 // Devuelve true si aún hay vuelos por realizar
 func (s *Simulador) DebeContinuar() bool {
-	return false
+	if len(s.sigoa.Vuelos()) == 0 {
+		return false
+	}
+
+	ultima := s.sigoa.ObtenerHoraDelUltimoVuelo()
+	return s.hora.Before(ultima.Add(1 * time.Hour))
 }
 
 // Ejecuta un tick de la simulación
 func (s *Simulador) Tick() {
-	// TODO: procesar
+	// Generar llegada aleatoria de personas
+	if rand.Intn(10) < 3 {
+		p := NewPersona(uint(rand.Intn(1000000)), &Equipaje{Bultos: 1, PesoTotal: 20})
+		s.personas = append(s.personas, p)
+		if len(s.mostradores) == 0 {
+			s.mostradores = append(s.mostradores, NewMostrador(true))
+		}
+		s.mostradores[rand.Intn(len(s.mostradores))].HacerCola(p)
+	}
+
+	// Actualizar mostradores
+	for _, m := range s.mostradores {
+		m.Tick()
+	}
+
 	s.hora = s.hora.Add(time.Minute)
 }


### PR DESCRIPTION
## Summary
- add slice based queue to `Mostrador`
- track state changes in `Persona`
- implement check-in processing in `Mostrador.Tick`
- drive the simulation with random arrivals in `Simulador`
- stop simulation once all flights have departed

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68459e9fafc08332b34d0ded9f687dc5